### PR TITLE
Fix offsetGet method

### DIFF
--- a/src/SamBurns/Pimple3ContainerInterop/ServiceContainer.php
+++ b/src/SamBurns/Pimple3ContainerInterop/ServiceContainer.php
@@ -71,7 +71,7 @@ class ServiceContainer implements ContainerInterface, \ArrayAccess
 
     public function offsetGet($serviceId)
     {
-        $this->get($serviceId);
+        return $this->get($serviceId);
     }
 
     public function offsetExists($serviceId)


### PR DESCRIPTION
`$container['service']` accesses were broken due to a missing `return` statement.
